### PR TITLE
Using development version of React by default when devtools active

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1658,9 +1658,10 @@
       "dev": true
     },
     "@types/systemjs": {
-      "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/@types/systemjs/-/systemjs-0.20.6.tgz",
-      "integrity": "sha512-p3yv9sBBJXi3noUG216BpUI7VtVBUAvBIfZNTiDROUY31YBfsFHM4DreS7XMekN8IjtX0ysvCnm6r3WnirnNeA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@types/systemjs/-/systemjs-6.1.0.tgz",
+      "integrity": "sha512-akhlviqwowzRNiz3ooAbkjvyMO8cikBqap9z/0yfvMAb6vIsp91Rfox67qtgIhZosWP01MVSTwsgSFYWo4SWQA==",
+      "dev": true
     },
     "@types/tapable": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@openmrs/react-root-decorator": "^1.0.0",
     "@reach/tabs": "^0.1.6",
     "@types/jest": "^24.0.18",
+    "@types/systemjs": "^6.1.0",
     "babel-eslint": "^11.0.0-beta.0",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.5",
@@ -70,7 +71,6 @@
     "@types/react": "^16.9.2",
     "@types/react-dom": "^16.9.0",
     "@types/single-spa-react": "^2.8.3",
-    "@types/systemjs": "^0.20.6",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@openmrs/react-root-decorator": "^1.0.0",
     "@reach/tabs": "^0.1.6",
     "@types/jest": "^24.0.18",
-    "@types/systemjs": "^6.1.0",
     "babel-eslint": "^11.0.0-beta.0",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.5",
@@ -71,6 +70,7 @@
     "@types/react": "^16.9.2",
     "@types/react-dom": "^16.9.0",
     "@types/single-spa-react": "^2.8.3",
+    "@types/systemjs": "^6.1.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/src/devtools/devtools.component.tsx
+++ b/src/devtools/devtools.component.tsx
@@ -2,12 +2,11 @@ import React, { useState, useEffect } from "react";
 import DevToolsPopup from "./devtools-popup.component";
 import styles from "./devtools.styles.css";
 import { a, m } from "kremling";
+import { importMapOverridden } from "./import-map.component";
 
 export default function Root(props) {
   const [devToolsOpen, setDevToolsOpen] = useState(false);
-  const [isOverridden, setIsOverridden] = useState(
-    (window as any).importMapOverrides.hasOverrides
-  );
+  const [isOverridden, setIsOverridden] = useState(importMapOverridden());
 
   return (
     <>

--- a/src/devtools/devtools.component.tsx
+++ b/src/devtools/devtools.component.tsx
@@ -6,7 +6,7 @@ import { importMapOverridden } from "./import-map.component";
 
 export default function Root(props) {
   const [devToolsOpen, setDevToolsOpen] = useState(false);
-  const [isOverridden, setIsOverridden] = useState(importMapOverridden());
+  const [isOverridden, setIsOverridden] = useState(importMapOverridden);
 
   return (
     <>

--- a/src/devtools/import-map.component.tsx
+++ b/src/devtools/import-map.component.tsx
@@ -16,7 +16,7 @@ export default function ImportMap(props: ImportMapProps) {
       );
 
     function handleImportMapChange(evt) {
-      props.toggleOverridden((window as any).importMapOverrides.hasOverrides());
+      props.toggleOverridden(importMapOverridden());
     }
   }, [importMapListRef.current]);
 
@@ -26,6 +26,14 @@ export default function ImportMap(props: ImportMapProps) {
         ref={importMapListRef}
       ></import-map-overrides-list>
     </div>
+  );
+}
+
+export function importMapOverridden(): boolean {
+  return (
+    Object.keys(
+      (window as any).importMapOverrides.getOverrideMap().imports
+    ).filter(k => k !== "react" && k !== "react-dom").length > 0
   );
 }
 

--- a/src/root.component.tsx
+++ b/src/root.component.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import Devtools from "./devtools/devtools.component";
 import openmrsRootDecorator from "@openmrs/react-root-decorator";
+import { useDevelopmentReact } from "./use-development-react.hook";
 
 function Root(props) {
+  useDevelopmentReact();
+
   return <Devtools {...props} />;
 }
 

--- a/src/use-development-react.hook.tsx
+++ b/src/use-development-react.hook.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+export function useDevelopmentReact() {
+  React.useEffect(() => {
+    if (!localStorage.getItem("prod-react")) {
+      const reactUrl = System.resolve("react");
+      const reactDOMUrl = System.resolve("react-dom");
+      // @ts-ignore
+      window.importMapOverrides.addOverride(
+        "react",
+        reactUrl.replace("production.min", "development")
+      );
+      // @ts-ignore
+      window.importMapOverrides.addOverride(
+        "react-dom",
+        reactDOMUrl.replace("production.min", "development")
+      );
+    }
+  }, [localStorage.getItem("prod-react")]);
+}


### PR DESCRIPTION
The development version of react shows helpful warnings and provides a better developer experience. It is a completely separate file from the production version of react, and we can use import map overrides to force developers into using the production version of react.