### PR TITLE
Decentralized Activation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ script:
   - npm run typescript
   - npm run build
   - echo "Folder name in Digital Ocean Spaces - $TRAVIS_COMMIT"
-  - mkdir -p dist/@openmrs/esm-devtools/$TRAVIS_COMMIT
-  - mv dist/*.* dist/@openmrs/esm-devtools/$TRAVIS_COMMIT/
+  - mkdir -p dist/@openmrs/esm-devtools-app/$TRAVIS_COMMIT
+  - mv dist/*.* dist/@openmrs/esm-devtools-app/$TRAVIS_COMMIT/
 deploy:
   provider: s3
   access_key_id: "$DIGITAL_OCEAN_SPACES_KEY_ID"
@@ -22,6 +22,7 @@ deploy:
   on:
     branch: master
 after_deploy:
-  - statuscode=$(curl --output /dev/null --write-out %{http_code} -u $DEPLOYER_USERNAME:$DEPLOYER_PASSWORD -d '{ "service":"@openmrs/esm-devtools","url":"https://spa-modules.nyc3.digitaloceanspaces.com/@openmrs/esm-devtools/'$TRAVIS_COMMIT'/openmrs-esm-devtools.js" }' -X PATCH $DEPLOYER_HOST/services\?env=prod -H "Accept:application/json" -H "Content-Type:application/json")
+  - echo "Updating import map to point to new version of @openmrs/esm-devtools-app"
+  - statuscode=$(curl --output /dev/null --write-out %{http_code} -u $DEPLOYER_USERNAME:$DEPLOYER_PASSWORD -d '{ "service":"@openmrs/esm-devtools-app","url":"https://spa-modules.nyc3.digitaloceanspaces.com/@openmrs/esm-devtools-app/'$TRAVIS_COMMIT'/openmrs-esm-devtools.js" }' -X PATCH $DEPLOYER_HOST/services\?env=prod -H "Accept:application/json" -H "Content-Type:application/json")
   - echo "Deployment Status Code --> ${statuscode}"
   - if [ "$statuscode" -ne 200 ]; then travis_terminate "$statuscode"; fi

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openmrs/esm-devtools",
+  "name": "@openmrs/esm-devtools-app",
   "description": "Dev tools for frontend devs using OpenMRS",
   "main": "dist/openmrs-esm-devtools.js",
   "version": "1.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import "./set-public-path";
 function setupOpenMRS() {
   return {
     lifecycle: () => import("./openmrs-esm-devtools"),
-    activate: () => !localStorage.getItem("openmrs:devtools"),
+    activate: () => !!localStorage.getItem("openmrs:devtools"),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,10 @@
+import "./set-public-path";
+
+function setupOpenMRS() {
+  return {
+    lifecycle: () => import("./openmrs-esm-devtools"),
+    activate: () => !localStorage.getItem("openmrs:devtools"),
+  };
+}
+
+export { setupOpenMRS };

--- a/src/openmrs-esm-devtools.tsx
+++ b/src/openmrs-esm-devtools.tsx
@@ -1,16 +1,13 @@
-import "./set-public-path";
 import "./openmrs-backend-dependencies";
 import React from "react";
 import ReactDOM from "react-dom";
 import Root from "./root.component";
 import singleSpaReact from "single-spa-react";
 
-const reactLifecycles = singleSpaReact({
+const { bootstrap, mount, unmount } = singleSpaReact({
   React,
   ReactDOM,
   rootComponent: Root,
 });
 
-export const bootstrap = reactLifecycles.bootstrap;
-export const mount = reactLifecycles.mount;
-export const unmount = reactLifecycles.unmount;
+export { bootstrap, mount, unmount };

--- a/src/set-public-path.ts
+++ b/src/set-public-path.ts
@@ -1,3 +1,3 @@
 import { setPublicPath } from "systemjs-webpack-interop";
 
-setPublicPath("@openmrs/esm-devtools");
+setPublicPath("@openmrs/esm-devtools-app");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,13 @@
 const path = require("path");
-const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const CleanWebpackPlugin = require("clean-webpack-plugin").CleanWebpackPlugin;
+const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 
 module.exports = {
-  entry: path.resolve(__dirname, "src/openmrs-esm-devtools.tsx"),
+  entry: path.resolve(__dirname, "src/index.ts"),
   output: {
-    libraryTarget: "system",
     filename: "openmrs-esm-devtools.js",
-    path: __dirname + "/dist",
+    libraryTarget: "system",
+    path: path.resolve(__dirname, "dist"),
     jsonpFunction: "webpackJsonp_openmrs_esm_devtools",
   },
   module: {
@@ -42,13 +42,6 @@ module.exports = {
       },
     ],
   },
-  externals: [
-    "react",
-    "react-dom",
-    /^@openmrs\/esm/,
-    "i18next",
-    "react-i18next",
-  ],
   devtool: "sourcemap",
   devServer: {
     headers: {
@@ -56,8 +49,17 @@ module.exports = {
     },
     disableHostCheck: true,
   },
+  externals: [
+    /^@openmrs\/esm.*/,
+    "i18next",
+    "single-spa",
+    "react",
+    "react-dom",
+    "react-i18next",
+    "react-router-dom",
+  ],
+  plugins: [new ForkTsCheckerWebpackPlugin(), new CleanWebpackPlugin()],
   resolve: {
     extensions: [".tsx", ".ts", ".jsx", ".js"],
   },
-  plugins: [new ForkTsCheckerWebpackPlugin(), new CleanWebpackPlugin()],
 };


### PR DESCRIPTION
Refactored to use `decentralized-activation`.

**Important**:
The module name has to be renamed with a suffix of `-app`. As outlined last week we should also rename the repository then.